### PR TITLE
Fixes vault key and text display not updated when config is updated

### DIFF
--- a/src/main/java/io/github/derec4/elytraVaults/listeners/SpawnVaultListener.java
+++ b/src/main/java/io/github/derec4/elytraVaults/listeners/SpawnVaultListener.java
@@ -1,17 +1,22 @@
 package io.github.derec4.elytraVaults.listeners;
 
 import io.github.derec4.elytraVaults.ElytraVaults;
+import io.github.derec4.elytraVaults.utils.BlockUtils;
+import io.github.derec4.elytraVaults.utils.TextDisplayUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.Vault;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.TextDisplay;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootTable;
 
 import static io.github.derec4.elytraVaults.utils.BlockUtils.createElytraVault;
 import static io.github.derec4.elytraVaults.utils.TextDisplayUtils.spawnVaultTextDisplays;
@@ -30,17 +35,18 @@ public class SpawnVaultListener implements Listener {
             return;
         }
 
-        if (!event.isNewChunk()) {
-            return;
+        if (event.isNewChunk()) {
+            processItemFrames(event);
+        } else {
+            processVaultBlocks(event);
+            processTextDisplays(event);
         }
-
-        processChunkEntities(event);
     }
 
     /**
      * Processes all entities in the loaded chunk and searches for an Elytra Item Frame entity
      */
-    private void processChunkEntities(ChunkLoadEvent event) {
+    private void processItemFrames(ChunkLoadEvent event) {
         for (var entity : event.getChunk().getEntities()) {
             if (entity.getType() != EntityType.ITEM_FRAME) {
                 continue;
@@ -91,5 +97,60 @@ public class SpawnVaultListener implements Listener {
         }
 
         frame.remove();
+    }
+
+    /**
+     * Processes all block entities to update all the vaults
+     */
+    private void processVaultBlocks(ChunkLoadEvent event) {
+        for (var block : event.getChunk().getTileEntities()) {
+            if (block.getType() != Material.VAULT) {
+                continue;
+            }
+            Vault vault = (Vault) block;
+            LootTable lootTable = vault.getLootTable();
+            if (!lootTable.getKey().equals(BlockUtils.getElytraVaultLootTableKey())) {
+                continue;
+            }
+            plugin.getLogger().info("Elytra Vault detected at " + vault.getLocation());
+            processVault(vault);
+        }
+    }
+
+    /**
+     * Processes an Elytra Vault
+     * This method updates the key item
+     */
+    private void processVault(Vault vault) {
+        Material keyItemMaterial = plugin.getConfigManager().getKeyItem();
+        vault.setKeyItem(new ItemStack(keyItemMaterial));
+        vault.update();
+    }
+
+    /**
+     * Processes all text displays
+     */
+    private void processTextDisplays(ChunkLoadEvent event) {
+        for (var entity : event.getChunk().getEntities()) {
+            if (entity.getType() != EntityType.TEXT_DISPLAY) {
+                continue;
+            }
+            TextDisplay textDisplay = (TextDisplay) entity;
+            if (textDisplay.text().toString().contains("Open With ")
+                    && textDisplay.getScoreboardTags().contains("elytra_vault_text")) {
+                plugin.getLogger().info("Key Item Text Display detected at " + textDisplay.getLocation());
+                processKeyItemTextDisplay(textDisplay);
+            }
+        }
+    }
+
+    /**
+     * Processes a Text Display
+     * This method updates the shown item in the display
+     */
+    private void processKeyItemTextDisplay(TextDisplay textDisplay) {
+        // This works perfectly fine now, but it may not have good enough stability.
+        Material keyItemMaterial = plugin.getConfigManager().getKeyItem();
+        textDisplay.text(TextDisplayUtils.getKeyDisplayText(keyItemMaterial));
     }
 }

--- a/src/main/java/io/github/derec4/elytraVaults/utils/BlockUtils.java
+++ b/src/main/java/io/github/derec4/elytraVaults/utils/BlockUtils.java
@@ -24,6 +24,10 @@ public class BlockUtils {
         return targetBlock;
     }
 
+    public static NamespacedKey getElytraVaultLootTableKey() {
+        return new NamespacedKey("elytra_vault", "elytra_vault");
+    }
+
     public static Vault createElytraVault (Block block, JavaPlugin plugin, Material keyItemMaterial) {
         // 12.19.2025 after looking a ton, this part with loot table can be done SO easily by adding a datapack
         // with this plugin using Paper, but then Spigot servers cant use it. For now I will manually create since
@@ -34,7 +38,7 @@ public class BlockUtils {
             return null;
         }
 
-        NamespacedKey lootTableKey = new NamespacedKey("elytra_vault", "elytra_vault");
+        NamespacedKey lootTableKey = getElytraVaultLootTableKey();
         LootTable lootTable = Bukkit.getLootTable(lootTableKey);
 
         vault.setKeyItem(new ItemStack(keyItemMaterial));

--- a/src/main/java/io/github/derec4/elytraVaults/utils/TextDisplayUtils.java
+++ b/src/main/java/io/github/derec4/elytraVaults/utils/TextDisplayUtils.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.block.Block;
@@ -24,9 +25,7 @@ public class TextDisplayUtils {
         });
 
         block.getWorld().spawn(new Location(block.getWorld(), cx, topY + 0.05, cz), TextDisplay.class, td -> {
-            String keyItemName = formatMaterialName(keyItemMaterial);
-            Component keyText = Component.text("Open With ")
-                    .append(Component.text("[" + keyItemName + "]").color(NamedTextColor.AQUA));
+            Component keyText = getKeyDisplayText(keyItemMaterial);
 
             td.text(keyText);
             td.setBillboard(Display.Billboard.CENTER);
@@ -36,18 +35,15 @@ public class TextDisplayUtils {
         });
     }
 
-    private static String formatMaterialName(Material material) {
-        String[] words = material.name().toLowerCase().split("_");
-        StringBuilder formatted = new StringBuilder();
+    public static Component getKeyDisplayText(Material keyMaterial) {
+        return Component.text("Open With ")
+                .append(formatMaterialName(keyMaterial).color(NamedTextColor.AQUA));
+    }
 
-        for (int i = 0; i < words.length; i++) {
-            if (i > 0) {
-                formatted.append(" ");
-            }
-            formatted.append(words[i].substring(0, 1).toUpperCase())
-                    .append(words[i].substring(1));
-        }
-
-        return formatted.toString();
+    private static Component formatMaterialName(Material material) {
+        NamespacedKey key = material.getKey();
+        String langkey = String.format("item.%s.%s", key.getNamespace(), key.getKey());
+        return Component.text("[").append(Component.translatable(langkey))
+                .append(Component.text("]"));
     }
 }


### PR DESCRIPTION
Previously when the key item is changed in the config file, it only affects newly generated chunks. Now I updated the plugin so that existing vaults can be updated to the new key item, and the text display is also updated.

I also updated the text display so that the translated name is displayed according to the clients' language, instead of always using the item's ID.